### PR TITLE
args, create, open 함수 구현 통과 코드입니다.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,8 @@
         "init.h": "c",
         "string_view": "c",
         "atomic": "c",
-        "timer.h": "c"
+        "timer.h": "c",
+        "istream": "c",
+        "limits": "c"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,14 @@
         "*.inc": "c",
         "stdio.h": "c",
         "syscall.h": "c",
-        "syscall-nr.h": "c"
+        "syscall-nr.h": "c",
+        "stdint.h": "c",
+        "exception": "c",
+        "fstream": "c",
+        "iosfwd": "c",
+        "new": "c",
+        "ostream": "c",
+        "sstream": "c",
+        "streambuf": "c"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,10 @@
         "new": "c",
         "ostream": "c",
         "sstream": "c",
-        "streambuf": "c"
+        "streambuf": "c",
+        "process.h": "c",
+        "inttypes.h": "c",
+        "directory.h": "c",
+        "debug.h": "c"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
         "synch.h": "c",
         "stdbool.h": "c",
         "thread.h": "c",
-        "*.inc": "c"
+        "*.inc": "c",
+        "stdio.h": "c",
+        "syscall.h": "c",
+        "syscall-nr.h": "c"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,14 @@
         "inttypes.h": "c",
         "directory.h": "c",
         "debug.h": "c",
-        "stdlib.h": "c"
+        "stdlib.h": "c",
+        "main.h": "c",
+        "cstdlib": "c",
+        "lib.h": "c",
+        "off_t.h": "c",
+        "gdt.h": "c",
+        "intrinsic.h": "c",
+        "flags.h": "c",
+        "init.h": "c"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,7 @@
         "process.h": "c",
         "inttypes.h": "c",
         "directory.h": "c",
-        "debug.h": "c"
+        "debug.h": "c",
+        "stdlib.h": "c"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,9 @@
         "gdt.h": "c",
         "intrinsic.h": "c",
         "flags.h": "c",
-        "init.h": "c"
+        "init.h": "c",
+        "string_view": "c",
+        "atomic": "c",
+        "timer.h": "c"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,6 +32,8 @@
         "atomic": "c",
         "timer.h": "c",
         "istream": "c",
-        "limits": "c"
+        "limits": "c",
+        "interrupt.h": "c",
+        "file.h": "c"
     }
 }

--- a/pintos-kaist/include/threads/thread.h
+++ b/pintos-kaist/include/threads/thread.h
@@ -101,9 +101,21 @@ struct thread {
 	struct list_elem elem;              /* List element. */
 	struct list_elem d_elem;            /* Donations List element. */
 
+	struct thread *parentThread;
+	struct list siblingThread;
+	struct list_elem childThread;
+	struct file **fbt;
+	int next_fd;
+
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4;                     /* Page map level 4 */
+	// struct thread *parentThread;
+	// struct list siblingThread;
+	// struct list_elem childThread;
+	// struct file file_fdt[64];
+	// int next_fd;
+	// 초기화 구문 필요
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */

--- a/pintos-kaist/include/threads/thread.h
+++ b/pintos-kaist/include/threads/thread.h
@@ -101,10 +101,10 @@ struct thread {
 	struct list_elem elem;              /* List element. */
 	struct list_elem d_elem;            /* Donations List element. */
 
+	struct file *fd_table[64];
 	struct thread *parentThread;
 	struct list siblingThread;
 	struct list_elem childThread;
-	struct file **fbt;
 	int next_fd;
 
 #ifdef USERPROG

--- a/pintos-kaist/include/threads/thread.h
+++ b/pintos-kaist/include/threads/thread.h
@@ -5,6 +5,8 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+
+#include "threads/synch.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -106,6 +108,8 @@ struct thread {
 	struct list siblingThread;
 	struct list_elem childThread;
 	int next_fd;
+	
+	struct semaphore threadSema;
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/pintos-kaist/include/userprog/process.h
+++ b/pintos-kaist/include/userprog/process.h
@@ -3,9 +3,19 @@
 
 #include "threads/thread.h"
 
+struct kernel_args{
+	int argc;
+	char *argv[32];
+	char raw[128];
+};
+
+void stack_update(int argc, char* argv[], void **stackptr);
+
 tid_t process_create_initd (const char *file_name);
 tid_t process_fork (const char *name, struct intr_frame *if_);
 int process_exec (void *f_name);
+
+void processOff();
 int process_wait (tid_t);
 void process_exit (void);
 void process_activate (struct thread *next);

--- a/pintos-kaist/include/userprog/syscall.h
+++ b/pintos-kaist/include/userprog/syscall.h
@@ -1,6 +1,24 @@
 #ifndef USERPROG_SYSCALL_H
 #define USERPROG_SYSCALL_H
 
+#include <stdbool.h>
+#include <threads/thread.h>
+
 void syscall_init (void);
+
+void halt(void);
+void exit(int status);
+tid_t fork (const char *thread_name);
+int exec(const char *cmd_line);
+int wait(tid_t pid);
+bool create(const char *file, unsigned initial_size);
+bool remove(const char *file);
+int open(const char *file);
+int filesize(int fd);
+int read(int fd, void *buffer, unsigned size);
+int write(int fd, const void *buffer);
+void seek(int fd, unsigned position);
+unsigned tell(int fd);
+void close(int fd);
 
 #endif /* userprog/syscall.h */

--- a/pintos-kaist/include/userprog/syscall.h
+++ b/pintos-kaist/include/userprog/syscall.h
@@ -16,7 +16,7 @@ bool remove(const char *file);
 int open(const char *file);
 int filesize(int fd);
 int read(int fd, void *buffer, unsigned size);
-int write(int fd, const void *buffer);
+int write(int fd, const void *buffer, unsigned size);
 void seek(int fd, unsigned position);
 unsigned tell(int fd);
 void close(int fd);

--- a/pintos-kaist/tests/userprog/create-exists.c
+++ b/pintos-kaist/tests/userprog/create-exists.c
@@ -14,3 +14,4 @@ test_main (void)
   CHECK (create ("baffle.dat", 0), "create baffle.dat");
   CHECK (!create ("warble.dat", 0), "try to re-create quux.dat");
 }
+

--- a/pintos-kaist/threads/thread.c
+++ b/pintos-kaist/threads/thread.c
@@ -229,7 +229,6 @@ thread_create (const char *name, int priority,
 	if(t->priority > thread_current()->priority)
 		thread_yield();
 
-
 	return tid;								// 생성된 스레드의 ID 반환
 }
 

--- a/pintos-kaist/threads/thread.c
+++ b/pintos-kaist/threads/thread.c
@@ -230,7 +230,6 @@ thread_create (const char *name, int priority,
 	// userprog 확장을 위한 추가된 쓰레드 멤버변수 초기화 과정
 	t->parentThread = NULL;
 	list_init(&t->siblingThread);
-	t->next_fd = 0;
 
 	// 스레드를 READY 상태로 전환하고 ready_list에 삽입하기
 	thread_unblock (t);

--- a/pintos-kaist/threads/thread.c
+++ b/pintos-kaist/threads/thread.c
@@ -189,6 +189,7 @@ tid_t
 thread_create (const char *name, int priority,
 		thread_func *function, void *aux) {
 	struct thread *t;
+	//struct kernel_thread_frame *kf;
 	tid_t tid;
 
 	ASSERT (function != NULL);			// 실행할 함수는 NULL일 수 없음
@@ -215,14 +216,19 @@ thread_create (const char *name, int priority,
 	list_init(&t->donations);
 	t->wait_on_lock = NULL;
 	t->base_priority = t->priority;
-	/* 4. 스레드를 READY 상태로 전환하고 ready_list에 삽입 */
+
+	// userprog 확장을 위한 추가된 쓰레드 멤버변수 초기화 과정
+	t->parentThread = NULL;
+	list_init(&t->siblingThread);
+	t->next_fd = 0;
+
+	// 스레드를 READY 상태로 전환하고 ready_list에 삽입하기
 	thread_unblock (t);
 	
 	/** project1-Priority Scheduling */
 	if(t->priority > thread_current()->priority)
 		thread_yield();
 
-	// preempt_priority();	// 🔥 removed: thread_unblock already handles preemption logic
 
 	return tid;								// 생성된 스레드의 ID 반환
 }

--- a/pintos-kaist/threads/thread.c
+++ b/pintos-kaist/threads/thread.c
@@ -216,6 +216,16 @@ thread_create (const char *name, int priority,
 	list_init(&t->donations);
 	t->wait_on_lock = NULL;
 	t->base_priority = t->priority;
+	
+	struct file *stdin;
+	struct file *stdout;
+	struct file *stderr;
+
+	t->fd_table[0] = stdin;
+	t->fd_table[1] = stdout;
+	t->fd_table[2] = stderr;
+	t->next_fd = 3;
+
 
 	// userprog 확장을 위한 추가된 쓰레드 멤버변수 초기화 과정
 	t->parentThread = NULL;
@@ -488,6 +498,14 @@ thread_exit (void) {
 
 #ifdef USERPROG
 	processOff();
+	struct thread *curr = thread_current();
+	for(int i = 0; i < 64; i++)
+	{
+		// free?
+		// 여기서하는거 아니고 close 해야하는거 아니야?
+		curr->fd_table[i] = NULL;
+	}
+
 	process_exit ();
 #endif
 

--- a/pintos-kaist/threads/thread.c
+++ b/pintos-kaist/threads/thread.c
@@ -717,10 +717,12 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->priority = priority;
 	t->magic = THREAD_MAGIC;
 
-	// TODO SOL.
 	t->wait_on_lock = NULL;
 	t->base_priority = priority;
 	list_init(&t->donations);
+
+	t->threadSema.value = 1;
+	list_init(&t->threadSema.waiters);
 
 	
 }

--- a/pintos-kaist/threads/thread.c
+++ b/pintos-kaist/threads/thread.c
@@ -212,7 +212,7 @@ thread_create (const char *name, int priority,
 	t->tf.ss = SEL_KDSEG;                   // 스택 세그먼트
 	t->tf.cs = SEL_KCSEG;                   // 코드 세그먼트
 	t->tf.eflags = FLAG_IF;                 // 인터럽트 플래그 설정
-
+	
 	list_init(&t->donations);
 	t->wait_on_lock = NULL;
 	t->base_priority = t->priority;
@@ -487,6 +487,7 @@ thread_exit (void) {
 	ASSERT (!intr_context ());
 
 #ifdef USERPROG
+	processOff();
 	process_exit ();
 #endif
 

--- a/pintos-kaist/userprog/process.c
+++ b/pintos-kaist/userprog/process.c
@@ -47,7 +47,8 @@ process_init (void) {
 tid_t
 process_create_initd (const char *file_name) {
 	char *fn_copy;
-		tid_t tid;
+	char *threadName = palloc_get_page(PAL_ZERO);
+	tid_t tid;
 	fn_copy = palloc_get_page (0);
 
 	char *ptr;
@@ -56,14 +57,20 @@ process_create_initd (const char *file_name) {
 	if (fn_copy == NULL)
 		return TID_ERROR;
 	strlcpy (fn_copy, file_name, PGSIZE);
-	// ptr = strtok_r(fn_copy, ' ', &nextptr);
+	strlcpy (threadName, file_name, PGSIZE);
 
-// file_name을 split 해야 할 것 같은뎅
-	tid = thread_create (file_name, PRI_DEFAULT, initd, fn_copy);
+	ptr = strtok_r(threadName, " \t\r\n", &nextptr);
+
+	tid = thread_create (ptr, PRI_DEFAULT, initd, fn_copy);
 	
 	if (tid == TID_ERROR)
-			palloc_free_page (fn_copy);
-			return tid;
+	{
+		palloc_free_page (fn_copy);
+		palloc_free_page(threadName);
+	}
+
+
+	return tid;
 }
 
 /* A thread function that launches first user process. */

--- a/pintos-kaist/userprog/process.c
+++ b/pintos-kaist/userprog/process.c
@@ -46,30 +46,25 @@ process_init (void) {
  * Notice that THIS SHOULD BE CALLED ONCE. */
 tid_t
 process_create_initd (const char *file_name) {
-	char *fn_copy;
+	char *fn_copy, *ptr, *nextptr;
 	char *threadName = palloc_get_page(PAL_ZERO);
 	tid_t tid;
 	fn_copy = palloc_get_page (0);
 
-	char *ptr;
-	char *nextptr;
-
 	if (fn_copy == NULL)
 		return TID_ERROR;
+
 	strlcpy (fn_copy, file_name, PGSIZE);
-	strlcpy (threadName, file_name, PGSIZE);
+	strlcpy (threadName, file_name, PGSIZE); 
 
 	ptr = strtok_r(threadName, " \t\r\n", &nextptr);
-
 	tid = thread_create (ptr, PRI_DEFAULT, initd, fn_copy);
 	
 	if (tid == TID_ERROR)
 	{
-		palloc_free_page (fn_copy);
+		palloc_free_page(fn_copy);
 		palloc_free_page(threadName);
 	}
-
-
 	return tid;
 }
 
@@ -181,14 +176,12 @@ process_exec (void *f_name) {
 	char *file_name = f_name;
 	bool success;
 	
-	char *tmp_fileName = palloc_get_page(PAL_USER | PAL_ZERO);
 	char *saveptr, *token;
 	char *args_ptr[32] = {NULL};
 	
-	if(tmp_fileName == NULL)
+	if(f_name == NULL)
 		return TID_ERROR;
 
-	strlcpy(tmp_fileName, file_name, PGSIZE);
 	int argc = 0;
 
 	for(token = strtok_r(f_name, " \t\r\n", &saveptr); token && argc < 31; token = strtok_r(NULL, " \t\r\n", &saveptr))
@@ -243,10 +236,7 @@ _if.rsp -= sizeof(void*);
 
 _if.R.rdi = argc;
 
-	/* If load failed, quit. */
 	palloc_free_page (file_name);
-	palloc_free_page (tmp_fileName);
-	
 
 	if (!success)
 		return -1;
@@ -255,6 +245,15 @@ _if.R.rdi = argc;
 	NOT_REACHED ();
 }
  
+
+
+int isWaitOn = 1;
+
+void processOff()
+{
+	isWaitOn = 0;
+}
+
 
 /* Waits for thread TID to die and returns its exit status.  If
  * it was terminated by the kernel (i.e. killed due to an
@@ -265,13 +264,6 @@ _if.R.rdi = argc;
  *
  * This function will be implemented in problem 2-2.  For now, it
  * does nothing. */
-int isWaitOn = 1;
-
-void processOff()
-{
-	isWaitOn = 0;
-}
-
 int
 process_wait (tid_t child_tid UNUSED) {
 	// 힌트 번역

--- a/pintos-kaist/userprog/process.c
+++ b/pintos-kaist/userprog/process.c
@@ -143,6 +143,11 @@ __do_fork (void *aux) {
 	/* 1. Read the cpu context to local stack. */
 	memcpy (&if_, parent_if, sizeof (struct intr_frame));
 
+	current->tf.R.rbx = if_.R.rbx;
+	current->tf.rsp = if_.rsp;
+	current->tf.R.rbp
+
+
 	/* 2. Duplicate PT */
 	current->pml4 = pml4_create();
 	if (current->pml4 == NULL)

--- a/pintos-kaist/userprog/process.c
+++ b/pintos-kaist/userprog/process.c
@@ -47,7 +47,7 @@ process_init (void) {
 tid_t
 process_create_initd (const char *file_name) {
 	char *fn_copy;
-	tid_t tid;
+		tid_t tid;
 	fn_copy = palloc_get_page (0);
 
 	char *ptr;
@@ -58,12 +58,12 @@ process_create_initd (const char *file_name) {
 	strlcpy (fn_copy, file_name, PGSIZE);
 	// ptr = strtok_r(fn_copy, ' ', &nextptr);
 
-	// file_name을 split 해야 할 것 같은뎅
+// file_name을 split 해야 할 것 같은뎅
 	tid = thread_create (file_name, PRI_DEFAULT, initd, fn_copy);
 	
 	if (tid == TID_ERROR)
-		palloc_free_page (fn_copy);
-	return tid;
+			palloc_free_page (fn_copy);
+			return tid;
 }
 
 /* A thread function that launches first user process. */

--- a/pintos-kaist/userprog/process.c
+++ b/pintos-kaist/userprog/process.c
@@ -49,6 +49,8 @@ process_create_initd (const char *file_name) {
 	if (fn_copy == NULL)
 		return TID_ERROR;
 	strlcpy (fn_copy, file_name, PGSIZE);
+	// TODO : 입력 받은 file_name은 arg 내용 전부 담고 있습니다. 띄어쓰기를 기준으로 구분 할 수 있어야합니다.
+	// strtok_r를 활용 해 볼 수 있습니다 : 공식 슬라이드 언급
 
 	/* Create a new thread to execute FILE_NAME. */
 	tid = thread_create (file_name, PRI_DEFAULT, initd, fn_copy);
@@ -201,9 +203,17 @@ process_exec (void *f_name) {
  * does nothing. */
 int
 process_wait (tid_t child_tid UNUSED) {
+	// 힌트 번역
+	// process wait 제대로 구현하기 전까지, 차라리 무한루프를 만드세요.
+	// process wait 구현은 system call 강의 14분대에서 확인하세요.
+
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
+	while(1)
+	{
+
+	}
 	return -1;
 }
 

--- a/pintos-kaist/userprog/syscall.c
+++ b/pintos-kaist/userprog/syscall.c
@@ -39,8 +39,183 @@ syscall_init (void) {
 
 /* The main system call interface */
 void
-syscall_handler (struct intr_frame *f UNUSED) {
+syscall_handler (struct intr_frame *f) {
 	// TODO: Your implementation goes here.
+	switch(f->R.rax)
+	{
+	case SYS_HALT:
+		printf("half has called!\n\n");
+		break;
+	case SYS_EXIT:
+		printf("exit has called!\n\n");
+		break;
+	case SYS_FORK:
+		printf("fork has called!\n\n");
+		break;
+	case SYS_EXEC:
+		printf("exec has called!\n\n");
+		break;
+	case SYS_WAIT:
+		printf("wait has called!\n\n");
+		break;
+	case SYS_CREATE:
+		printf("create has called!\n\n");
+		break;
+	case SYS_REMOVE:
+		printf("remove has called!\n\n");
+		break;
+	case SYS_OPEN:
+		printf("open has called!\n\n");
+		break;
+	case SYS_FILESIZE:
+		printf("filesize has called!\n\n");
+		break;
+	case SYS_READ:
+		printf("read has called!\n\n");
+		break;
+	case SYS_WRITE:
+		printf("write has called!\n\n");
+		break;
+	case SYS_SEEK:
+		printf("seek has called!\n\n");
+		break;
+	case SYS_TELL:
+		printf("tell has called!\n\n");
+		break;
+	case SYS_CLOSE:
+		printf("close has called!\n\n");
+		break;
+	default:
+		printf("SERIOUS ERROR!!\n\n");
+		break;
+	}
+
 	printf ("system call!\n");
 	thread_exit ();
 }
+
+void halt(void)
+{
+	// TODO : Shutdown PintOS
+	// Use : shutdown_power_off(void)
+}
+
+void exit(int status)
+{
+	// TODO : Exit Process.
+	// Use : thread_exit(void)
+	// should print message :
+	// Name of process: exit(status)
+}
+tid_t fork (const char *thread_name)
+{
+	// TODO :
+	// Create child process and execute program
+	// corresponds to cmd_line on it
+}
+
+int exec(const char *cmd_line)
+{
+	// TODO :
+	// Wait for termination of child process whose process id is pid
+}
+// 아니 슬라이드에서는 pid_t를 리턴하는 구현을 요구하는데 뭐지?
+
+// 여기까지 4개가 System과 직접 연관 된 내용들!
+
+/*
+	thread.h 에서 해야 할 일
+	Pointer to parent process : struct thread*
+	Pointer to the sibling : struct list
+	Pointer to the children : struct list_elem
+	추가 : 시스템 콜과 연계되어야 하여 우선 작성
+*/
+
+int wait(tid_t pid)
+{
+	// TODO :
+	// wait for a child process pid to exit and retrieve the child's exit status.
+	// IF : PID is alive
+		// wait till it terminates.
+		// Return the status that pid passed to exit.
+	// IF : PID did not call exit but was terminated by the kernel, return -1
+	// A parent process cna call wait for the cild process that has terminated
+		// - return exit status of the terminated child processes.
+
+	// After the child terminates, the parent should deallocatge its process descriptor
+		// wait fails and return -1 if
+			// pid does not refer to a direct child of the calling process.
+			// the process that calls wait has already called wait on pid.
+}
+bool create(const char *file, unsigned initial_size)
+{
+	// Create file which have size of initial_size
+	// use bool filesys_create const chr *name, off_t initial_size.
+	// return true if it is succeeded or false if it is not.
+	return false;
+}
+
+bool remove(const char *file)
+{
+	// Remove file whose name is file.
+	// Use bool filesys_remove(const char *name)
+	// Return true if it is succeeded or false if it is not.
+	// File is removed regardless of whether it is open or closed.
+	return false;
+}
+
+int open(const char *file)
+{
+	// Open the file corresponds to path in "file".
+	// Return its fd.
+	// use strung file *filesys_open(const char *name).
+	return 1;
+}
+
+int filesize(int fd)
+{
+	// Return the size, in bytes, of the file open as fd.
+	// Use off_t file_length(struct file *file).
+	return 1;
+}
+
+int read(int fd, void *buffer, unsigned size)
+{
+	// Read size bytes from the file open as fd into buffer.
+	// Return the number of bytes actually read (0 at end of file), or -1 if fails.
+	// If fd is 0, it reads from keyboard using input_getc(), otherwise reads from file using file_read() function.
+		// uint8_t input_getc(void)
+		// off_t file_read(struct file *file, void *buffer, off_t size)
+
+	return 0;
+}
+
+int write(int fd, const void *buffer)
+{
+	// Writes size bytes form buffer to the open file fd.
+	// Returns the number of bytes actually written.
+	// If fd is 1, it writes to the console using putbuf(), otherwise write to the file using file_write() function.
+		// void putbuf(const char *buffer, size_t n)
+		// off_t file_write(struct file *file, const void *buffer, off_t size)
+	return 1;
+}
+
+void seek(int fd, unsigned position)
+{
+	// Changes the next byte to be rtead or written in open file fd to position.
+	// use void file_seek
+}
+
+unsigned tell(int fd)
+{
+	// Return the position of the next byte to be read or written in open file fd.
+	// use off_t file_tell
+	return 0;
+}
+
+void close(int fd)
+{
+	// close file descriptor fd.
+	// use void file_close
+}
+

--- a/pintos-kaist/userprog/syscall.c
+++ b/pintos-kaist/userprog/syscall.c
@@ -77,7 +77,8 @@ syscall_handler (struct intr_frame *f) {
 		printf("read has called!\n\n");
 		break;
 	case SYS_WRITE:
-		write(f->R.rdi, f->R.rsi, f->R.rdx);
+		if(is_user_vaddr(f->R.rdi) && is_user_vaddr(f->R.rsi) && is_user_vaddr(f->R.rdx))
+			write(f->R.rdi, f->R.rsi, f->R.rdx);		
 		break;
 	case SYS_SEEK:
 		printf("seek has called!\n\n");

--- a/pintos-kaist/userprog/syscall.c
+++ b/pintos-kaist/userprog/syscall.c
@@ -217,6 +217,7 @@ wait하지 않으면 exit status가 유실되며, wait는 한 번만 가능하�
 			// pid does not refer to a direct child of the calling process.
 			// the process that calls wait has already called wait on pid.
 }
+
 bool create(const char *file, unsigned initial_size)
 {
 	if (pml4_get_page(thread_current()->pml4, file) == NULL) exit(-1);

--- a/pintos-kaist/userprog/syscall.c
+++ b/pintos-kaist/userprog/syscall.c
@@ -8,6 +8,8 @@
 #include "threads/flags.h"
 #include "intrinsic.h"
 
+#include "threads/init.h"
+
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
 
@@ -41,6 +43,7 @@ syscall_init (void) {
 void
 syscall_handler (struct intr_frame *f) {
 	// TODO: Your implementation goes here.
+	printf("syscall handler has called. \n");
 	switch(f->R.rax)
 	{
 	case SYS_HALT:
@@ -74,7 +77,7 @@ syscall_handler (struct intr_frame *f) {
 		printf("read has called!\n\n");
 		break;
 	case SYS_WRITE:
-		printf("write has called!\n\n");
+		write(f->R.rdi, f->R.rsi, f->R.rdx);
 		break;
 	case SYS_SEEK:
 		printf("seek has called!\n\n");
@@ -90,28 +93,26 @@ syscall_handler (struct intr_frame *f) {
 		break;
 	}
 
-	printf ("system call!\n");
-	thread_exit ();
+	//printf ("system call!\n");
+	//thread_exit ();
 }
 
 void halt(void)
 {
-	// TODO : Shutdown PintOS
-	// Use : shutdown_power_off(void)
+	power_off();
 }
 
 void exit(int status)
 {
-	// TODO : Exit Process.
-	// Use : thread_exit(void)
-	// should print message :
-	// Name of process: exit(status)
+	printf("Exiting : \n");
+	printf("Name of process: exit(%d)\n", status);
+	thread_exit();
 }
+
 tid_t fork (const char *thread_name)
 {
-	// TODO :
-	// Create child process and execute program
-	// corresponds to cmd_line on it
+	// TODO:
+	// Create child process and execute program corresponds to cmd_line on it
 }
 
 int exec(const char *cmd_line)
@@ -190,14 +191,21 @@ int read(int fd, void *buffer, unsigned size)
 	return 0;
 }
 
-int write(int fd, const void *buffer)
+int write(int fd, const void *buffer, unsigned size)
 {
-	// Writes size bytes form buffer to the open file fd.
-	// Returns the number of bytes actually written.
-	// If fd is 1, it writes to the console using putbuf(), otherwise write to the file using file_write() function.
-		// void putbuf(const char *buffer, size_t n)
+	if(fd == 1)
+	{
+		putbuf(buffer, size);
+	}
+	else
+	{
 		// off_t file_write(struct file *file, const void *buffer, off_t size)
-	return 1;
+		printf("CANNOT WRITE NOW! Implement first!\n");
+		// else 영역이 올바르게 구현되지 않았기에 -1 리턴하기.
+		return -1;
+	}
+	// TODO : return 값을 -1로 정의 할 여지를 고민해야함
+	return size;
 }
 
 void seek(int fd, unsigned position)

--- a/pintos-kaist/userprog/syscall.c
+++ b/pintos-kaist/userprog/syscall.c
@@ -43,14 +43,13 @@ syscall_init (void) {
 void
 syscall_handler (struct intr_frame *f) {
 	// TODO: Your implementation goes here.
-	printf("syscall handler has called. \n");
 	switch(f->R.rax)
 	{
 	case SYS_HALT:
 		printf("half has called!\n\n");
 		break;
 	case SYS_EXIT:
-		printf("exit has called!\n\n");
+		exit(0);
 		break;
 	case SYS_FORK:
 		printf("fork has called!\n\n");
@@ -105,8 +104,8 @@ void halt(void)
 
 void exit(int status)
 {
-	printf("Exiting : \n");
-	printf("Name of process: exit(%d)\n", status);
+	struct thread *curr = thread_current();
+	printf("%s: exit(%d)\n", curr->name, status);
 	thread_exit();
 }
 


### PR DESCRIPTION
안녕하세요. args, create, open 부분 테스트 케이스를 통과하는 코드의 Pull Request입니다.

코드 별 주요 작성 내용 요약 :

**thread.h / thread.c**
- 쓰레드 단위의 위계관계 정립을 위한 멤버변수 사전 선언하였습니다.
- 쓰레드 단위의 파일 디스크립터 저장을 위한 테이블을 생성 시점에 정의하였습니다.
- 파일 디스크립터 테이블 초기화 및 helper 변수인 `next_fd` 초기화 구문 작성하는 내용이 추가되었습니다.



**process.h / process.c**
- 기획 과정에서 kernel_args 구조체를 추가하였으나, 구현 과정에서 일부 문제가 있어 제거 하였습니다. 차후 재구현 예정입니다.
- 유저 프로그램을 담을 쓰레드 생성 시점에서 쓰레드가 올바른 이름이 담기도록 프로그램 이름만 파싱하는 구문 추가하였습니다.
- 인자 파싱 및 초기화 된 스택에 저장하는 내용 구현하였습니다.
- `process_wait()`을 `processOff()` 호출로 무한루프 탈출 할 수 있도록 하였습니다.



**syscall.h / syscall.c**
- 모든 시스템 콜 스켈레톤 구성하였습니다.
- `create`, `open` 모든 케이스 통과하도록 구현하였습니다.
- `write`는 `fd == 1`일때만 작동을 보장하며 그 외에는 추가 구현이 진행중에 있습니다. `args` 계열 테스트는 전부 통과합니다.